### PR TITLE
Remove windows workflow, since no pyscf available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
         include:
           - os: macos-latest
             python-version: 3.7
-          - os: windows-latest
-            python-version: 3.7
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
as suggested by @HuangJunye at https://github.com/qiskit-community/qiskit-application-modules-demo-sessions/pull/10#issuecomment-1108638143

